### PR TITLE
Support multiple configuration resolving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,7 +47,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -58,7 +58,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -203,12 +203,14 @@ dependencies = [
  "anyhow",
  "clap",
  "crossbeam",
+ "dirs",
  "extend",
  "indexmap",
  "parking_lot",
  "serde",
  "serde_json",
  "streaming-iterator",
+ "tempfile",
  "toml",
  "tree-sitter",
  "tree-sitter-c",
@@ -224,10 +226,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "errno"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "extend"
@@ -238,6 +271,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -282,6 +344,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
+name = "libredox"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,6 +382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,7 +407,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -345,12 +429,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -381,6 +482,19 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "ryu"
@@ -469,6 +583,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -637,12 +784,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -651,15 +837,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -669,9 +861,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -687,9 +891,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -699,9 +915,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -716,4 +944,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]

--- a/cymbal/Cargo.toml
+++ b/cymbal/Cargo.toml
@@ -11,6 +11,7 @@ readme = "../readme.md"
 anyhow = "1.0.97"
 clap = { version = "4.5.35", features = ["derive"] }
 crossbeam = "0.8.4"
+dirs = "5.0"
 extend = "1.2.0"
 indexmap = { version = "2.9.0", features = ["serde"] }
 parking_lot = "0.12.3"
@@ -29,3 +30,6 @@ tree-sitter-odin = "1.3.0"
 tree-sitter-python = "0.23.6"
 tree-sitter-rust = "0.24.0"
 tree-sitter-typescript = "0.23.2"
+
+[dev-dependencies]
+tempfile = "3.0"

--- a/cymbal/src/config.rs
+++ b/cymbal/src/config.rs
@@ -1,4 +1,5 @@
 pub mod raw;
+pub mod loader;
 
 use std::{collections::HashMap, sync::LazyLock};
 

--- a/cymbal/src/config/loader.rs
+++ b/cymbal/src/config/loader.rs
@@ -1,0 +1,143 @@
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+
+use super::raw::RawConfig;
+
+#[derive(Debug, Clone)]
+pub struct ConfigPaths {
+    pub global_config: Option<PathBuf>,
+    pub user_config: Option<PathBuf>,
+    pub project_config: Option<PathBuf>,
+}
+
+impl ConfigPaths {
+    pub fn detect() -> Self {
+        let global_config = dirs::config_dir().map(|dir| dir.join("cymbal").join("config.toml"));
+
+        let user_config = dirs::home_dir().map(|dir| dir.join(".cymbal.toml"));
+
+        let project_config = std::env::current_dir()
+            .ok()
+            .and_then(|mut dir| {
+                loop {
+                    let config_path = dir.join(".cymbal.toml");
+                    if config_path.exists() {
+                        return Some(config_path);
+                    }
+
+                    let cymbal_dir = dir.join(".cymbal");
+                    let cymbal_config = cymbal_dir.join("config.toml");
+                    if cymbal_config.exists() {
+                        return Some(cymbal_config);
+                    }
+
+                    if !dir.pop() {
+                        break;
+                    }
+                }
+                None
+            });
+
+        Self {
+            global_config,
+            user_config,
+            project_config,
+        }
+    }
+
+    pub fn iter_existing(&self) -> impl Iterator<Item = &PathBuf> {
+        [&self.global_config, &self.user_config, &self.project_config]
+            .into_iter()
+            .flatten()
+            .filter(|path| path.exists())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConfigLoader {
+    paths: ConfigPaths,
+}
+
+impl ConfigLoader {
+    pub fn new() -> Self {
+        Self {
+            paths: ConfigPaths::detect(),
+        }
+    }
+
+    pub fn load_merged_config(&self, user_specified_path: Option<&str>) -> Result<RawConfig> {
+        let mut merged_config = RawConfig::default();
+
+        for config_path in self.paths.iter_existing() {
+            let config_content = std::fs::read_to_string(config_path)
+                .with_context(|| format!("Failed to read config file: {}", config_path.display()))?;
+
+            let config: RawConfig = toml::from_str(&config_content)
+                .with_context(|| format!("Failed to parse config file: {}", config_path.display()))?;
+
+            merged_config = merge_configs(merged_config, config);
+        }
+
+        if let Some(user_path) = user_specified_path {
+            let user_config = if user_path.ends_with(".toml") {
+                let config_content = std::fs::read_to_string(user_path)
+                    .with_context(|| format!("Failed to read user-specified config: {}", user_path))?;
+
+                toml::from_str(&config_content)
+                    .with_context(|| format!("Failed to parse user-specified config: {}", user_path))?
+            } else {
+                toml::from_str(user_path)
+                    .context("Failed to parse user-specified config string")?
+            };
+
+            merged_config = merge_configs(merged_config, user_config);
+        }
+
+        Ok(merged_config)
+    }
+
+    pub fn get_config_paths(&self) -> &ConfigPaths {
+        &self.paths
+    }
+}
+
+fn merge_configs(mut base: RawConfig, overlay: RawConfig) -> RawConfig {
+    for (language, queries) in overlay.languages {
+        base.languages.insert(language, queries);
+    }
+    base
+}
+
+impl Default for ConfigLoader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_config_paths_detection() {
+        let paths = ConfigPaths::detect();
+
+        if let Some(global) = &paths.global_config {
+            assert!(global.ends_with("cymbal/config.toml"));
+        }
+
+        if let Some(user) = &paths.user_config {
+            assert!(user.ends_with(".cymbal.toml"));
+        }
+    }
+
+    #[test]
+    fn test_merge_configs() {
+        let base = RawConfig::default();
+        let overlay = RawConfig::default();
+
+        let merged = merge_configs(base, overlay);
+        assert!(!merged.languages.is_empty());
+    }
+}

--- a/cymbal/src/main.rs
+++ b/cymbal/src/main.rs
@@ -26,6 +26,10 @@ use crate::{args::Args, ext::Leak, walker::Walker, worker::Worker, writer::Write
 fn main() -> Result<(), anyhow::Error> {
   let args = Args::parse();
 
+  if args.show_config_paths {
+    return args.show_config_paths();
+  }
+
   match cymbal(&args) {
     Err(err) if args.debug => Err(err),
     _ => Ok(()),

--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,12 @@ Options:
 
           This can either be a path to a .toml file or a TOML string.
 
-          The default configuration will be applied if this argument is not provided or if it is the empty string.
+          Configs are merged in this order:
+          1. Default embedded config (lowest precedence)
+          2. Global config (~/.config/cymbal/config.toml or equivalent)
+          3. User home config (~/.cymbal.toml)
+          4. Project config (.cymbal.toml or .cymbal/config.toml, searched upward)
+          5. This explicit config argument (highest precedence)
 
       --cache-dir <CACHE_DIR>
           Directory to cache parsed symbols.
@@ -138,6 +143,17 @@ Options:
 ## Configuration
 `cymbal` is configured with [TOML][3] on a per-language basis. See
 [default-config.toml][4] for the default configuration.
+
+### Config File Precedence
+`cymbal` supports multiple configuration files that are merged in the following order (highest precedence last):
+
+1. **Default embedded config**: Built-in configuration for all supported languages
+2. **Global config**: `~/.config/cymbal/config.toml` (or platform equivalent)
+3. **User home config**: `~/.cymbal.toml`
+4. **Project config**: `.cymbal.toml` or `.cymbal/config.toml` (searched from current directory upward)
+5. **Explicit config**: Via `--config` command line argument
+
+Later configurations override earlier ones on a per-language basis. Use `--show-config-paths` to see which config files are detected and will be used.
 
 Each language has a set of queries for different kinds of symbols that can be
 found in that language. For example for C++,


### PR DESCRIPTION
Thanks for making such a cool tool! Very enjoyable to use. I've also implemented my own kks integration scripts!

* https://github.com/Yukaii/dotfiles/blob/320dd61fdecc57cff834d6fab6898b23c45cc59e/bin/.bin/kks-cymbal-workspace#L1
* https://github.com/Yukaii/dotfiles/blob/320dd61fdecc57cff834d6fab6898b23c45cc59e/bin/.bin/kks-cymbal-file#L1
  
<img width="1155" height="755" alt="スクリーンショット 2025-07-22 夜8 09 00" src="https://github.com/user-attachments/assets/c9c1a094-d174-4ca5-98ca-d92377fbce25" />

## Summary

I want to propose an addition to configuration resolving. Since I don't want to copy out the default config, and supply additional arguments in my usage script, I am adding configuration path resolution and supporting merging multiple configurations.

## Changes

- **Config merging**: Configs are now merged in order of precedence rather than replaced
- **Cross-platform paths**: Uses standard config directories on each platform
- **Project configs**: Searches upward for `.cymbal.toml` or `.cymbal/config.toml`
- **Debug flag**: New `--show-config-paths` to display detected config files

## Config Resolution Order

1. Default embedded config (lowest precedence)
2. Global config (`~/.config/cymbal/config.toml` or platform equivalent)
3. User home config (`~/.cymbal.toml`)
4. Project config (`.cymbal.toml` or `.cymbal/config.toml`, searched upward)
5. Explicit config via `--config` (highest precedence)

Later configs override earlier ones on a per-language basis.

## Backward Compatibility

Existing `--config` functionality remains unchanged. Users can continue using the tool exactly as before.

## Dependencies

- Added `dirs` crate for cross-platform directory detection
